### PR TITLE
Homebrew fix

### DIFF
--- a/opusenc-sys/build.rs
+++ b/opusenc-sys/build.rs
@@ -19,11 +19,18 @@ fn main() {
     println!("cargo:rerun-if-changed=wrapper.h");
 
     let mut clang_args = vec!();
+    if let Ok(opus_include) = std::env::var("OPUS_INCLUDE_DIR") {
+        clang_args.push("-I".into());
+        clang_args.push(opus_include);
+    }
 
     #[cfg(target_os = "macos")] {
         add_include("/opt/homebrew/include", &mut clang_args);
+        add_include("/opt/homebrew/include/opus", &mut clang_args);
         add_include("/usr/local/include", &mut clang_args);
+        add_include("/usr/local/include/opus", &mut clang_args);
         add_include("/usr/include", &mut clang_args);
+        add_include("/usr/include/opus", &mut clang_args);
 
         add_link_search(PathBuf::from("/opt/homebrew/lib"));
         add_link_search(PathBuf::from("/usr/local/lib"));
@@ -32,9 +39,15 @@ fn main() {
     #[cfg(not(target_os = "macos"))] {
         add_include("/usr/include", &mut clang_args);
         add_include("/usr/local/include", &mut clang_args);
+        add_include("/usr/include/opus", &mut clang_args);
+        add_include("/usr/local/include/opus", &mut clang_args);
 
         add_link_search(PathBuf::from("/usr/lib"));
         add_link_search(PathBuf::from("/usr/local/lib"));
+    }
+
+    if let Ok(opus_lib) = std::env::var("OPUS_LIB_DIR") {
+      println!("cargo:rustc-link-search={opus_lib}")
     }
 
     let bindings = bindgen::Builder::default()

--- a/opusenc-sys/build.rs
+++ b/opusenc-sys/build.rs
@@ -37,13 +37,9 @@ fn main() {
             "/opt/homebrew/lib",
             "/usr/local/lib"
         ];
-        for path in include_paths { 
-          add_include( PathBuf::from(path), &mut clang_args); 
-        }
-        for path in lib_paths { 
-          add_link_search(PathBuf::from(path)); 
-        }
 
+        include_paths.iter().for_each(|path| add_include(path, &mut clang_args));
+        lib_paths.iter().for_each(add_link_search);
     }
 
     #[cfg(not(target_os = "macos"))] {
@@ -59,8 +55,8 @@ fn main() {
             "/usr/local/lib"
         ];
 
-        for path in include_paths { add_include(path, &mut clang_args); }
-        for path in lib_paths { add_link_search(path); }
+        include_paths.iter().for_each(|path| add_include(path, &mut clang_args));
+        lib_paths.iter().for_each(add_link_search);
     }
 
     if let Ok(opus_lib) = std::env::var("OPUS_LIB_DIR") {

--- a/opusenc-sys/build.rs
+++ b/opusenc-sys/build.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 fn add_include<P: AsRef<std::path::Path>>(path: P, args: &mut Vec<String>) {
   if path.as_ref().exists() {
     args.push("-isystem".into());
-    args.push(path.as_ref().display());
+    args.push(path.as_ref().display().to_string());
   }
 }
 
@@ -15,35 +15,26 @@ fn add_link_search<P: AsRef<std::path::Path>>(path: P) {
 
 
 fn main() {
-    #[cfg(target_os = "macos")] {
-        if PathBuf::from("/opt/homebrew/lib").exists() {
-            println!("cargo:rustc-link-search=/opt/homebrew/lib");
-        }
-        if PathBuf::from("/usr/local/lib").exists() {
-            println!("cargo:rustc-link-search=/usr/local/lib");
-        }
-    }
-
-    #[cfg(not(target_os = "macos"))] {
-        println!("cargo:rustc-link-search=/usr/local/lib");
-    }
-
-
     println!("cargo:rustc-link-lib=opusenc");
     println!("cargo:rerun-if-changed=wrapper.h");
 
     let mut clang_args = vec!();
 
-
     #[cfg(target_os = "macos")] {
         add_include("/opt/homebrew/include", &mut clang_args);
         add_include("/usr/local/include", &mut clang_args);
         add_include("/usr/include", &mut clang_args);
+
+        add_link_search(PathBuf::from("/opt/homebrew/lib"));
+        add_link_search(PathBuf::from("/usr/local/lib"));
     }
 
     #[cfg(not(target_os = "macos"))] {
         add_include("/usr/include", &mut clang_args);
         add_include("/usr/local/include", &mut clang_args);
+
+        add_link_search(PathBuf::from("/usr/lib"));
+        add_link_search(PathBuf::from("/usr/local/lib"));
     }
 
     let bindings = bindgen::Builder::default()

--- a/opusenc-sys/build.rs
+++ b/opusenc-sys/build.rs
@@ -13,37 +13,54 @@ fn add_link_search<P: AsRef<std::path::Path>>(path: P) {
   }
 }
 
-
 fn main() {
     println!("cargo:rustc-link-lib=opusenc");
     println!("cargo:rerun-if-changed=wrapper.h");
 
-    let mut clang_args = vec!();
+    let mut clang_args = Vec::new();
     if let Ok(opus_include) = std::env::var("OPUS_INCLUDE_DIR") {
-        clang_args.push("-I".into());
+        clang_args.push("-isystem".into());
         clang_args.push(opus_include);
     }
 
     #[cfg(target_os = "macos")] {
-        add_include("/opt/homebrew/include", &mut clang_args);
-        add_include("/opt/homebrew/include/opus", &mut clang_args);
-        add_include("/usr/local/include", &mut clang_args);
-        add_include("/usr/local/include/opus", &mut clang_args);
-        add_include("/usr/include", &mut clang_args);
-        add_include("/usr/include/opus", &mut clang_args);
+        let include_paths= [
+            "/opt/homebrew/include",
+            "/usr/local/include", 
+            "/usr/include",
+            "/opt/homebrew/include/opus", 
+            "/usr/local/include/opus",
+            "/usr/include/opus",
+        ];
 
-        add_link_search(PathBuf::from("/opt/homebrew/lib"));
-        add_link_search(PathBuf::from("/usr/local/lib"));
+        let lib_paths = [
+            "/opt/homebrew/lib",
+            "/usr/local/lib"
+        ];
+        for path in include_paths { 
+          add_include( PathBuf::from(path), &mut clang_args); 
+        }
+        for path in lib_paths { 
+          add_link_search(PathBuf::from(path)); 
+        }
+
     }
 
     #[cfg(not(target_os = "macos"))] {
-        add_include("/usr/include", &mut clang_args);
-        add_include("/usr/local/include", &mut clang_args);
-        add_include("/usr/include/opus", &mut clang_args);
-        add_include("/usr/local/include/opus", &mut clang_args);
+        let include_paths= [
+            "/usr/include",
+            "/usr/local/include", 
+            "/usr/include/opus", 
+            "/usr/local/include/opus",
+        ];
 
-        add_link_search(PathBuf::from("/usr/lib"));
-        add_link_search(PathBuf::from("/usr/local/lib"));
+        let lib_paths = [
+            "/usr/lib",
+            "/usr/local/lib"
+        ];
+
+        for path in include_paths { add_include(path, &mut clang_args); }
+        for path in lib_paths { add_link_search(path); }
     }
 
     if let Ok(opus_lib) = std::env::var("OPUS_LIB_DIR") {

--- a/opusenc-sys/build.rs
+++ b/opusenc-sys/build.rs
@@ -1,12 +1,54 @@
 use std::path::PathBuf;
 
+fn add_include<P: AsRef<std::path::Path>>(path: P, args: &mut Vec<String>) {
+  if path.as_ref().exists() {
+    args.push("-isystem".into());
+    args.push(path.as_ref().display());
+  }
+}
+
+fn add_link_search<P: AsRef<std::path::Path>>(path: P) {
+  if path.as_ref().exists() {
+    println!("cargo:rustc-link-search={}", path.as_ref().display())
+  }
+}
+
+
 fn main() {
+    #[cfg(target_os = "macos")] {
+        if PathBuf::from("/opt/homebrew/lib").exists() {
+            println!("cargo:rustc-link-search=/opt/homebrew/lib");
+        }
+        if PathBuf::from("/usr/local/lib").exists() {
+            println!("cargo:rustc-link-search=/usr/local/lib");
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))] {
+        println!("cargo:rustc-link-search=/usr/local/lib");
+    }
+
+
     println!("cargo:rustc-link-lib=opusenc");
     println!("cargo:rerun-if-changed=wrapper.h");
 
+    let mut clang_args = vec!();
+
+
+    #[cfg(target_os = "macos")] {
+        add_include("/opt/homebrew/include", &mut clang_args);
+        add_include("/usr/local/include", &mut clang_args);
+        add_include("/usr/include", &mut clang_args);
+    }
+
+    #[cfg(not(target_os = "macos"))] {
+        add_include("/usr/include", &mut clang_args);
+        add_include("/usr/local/include", &mut clang_args);
+    }
+
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
-        .clang_args(["-isystem", "/usr/include/opus"])
+        .clang_args(&clang_args)
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .default_enum_style(bindgen::EnumVariation::ModuleConsts)
         .generate()


### PR DESCRIPTION
dadc6f31c76e80d569e0ecbbd525f17c51e47d65 Fixes:
Homebrew on macOS using Apple Silicon does not install under /usr/include/opus/, but under the /opt/homebrew/include
```stderr
   Compiling opusenc-sys v0.2.2
error: failed to run custom build command for `opusenc-sys v0.2.2`

Caused by:
  process didn't exit successfully: `/Users/viktorsandstrom/Documents/rust/tau-radio/target/debug/build/opusenc-sys-cbed859fac7156b2/build-script-build` (exit status: 101)
  --- stdout
  cargo:rustc-link-lib=opusenc
  cargo:rerun-if-changed=wrapper.h
  cargo:rerun-if-env-changed=TARGET
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_aarch64-apple-darwin
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS
  cargo:rerun-if-changed=wrapper.h

  --- stderr
  wrapper.h:1:10: fatal error: 'opus/opus_defines.h' file not found

  thread 'main' (9635381) panicked at /Users/viktorsandstrom/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opusenc-sys-0.2.2/build.rs:13:10:
  Unable to generate bindings: ClangDiagnostic("wrapper.h:1:10: fatal error: 'opus/opus_defines.h' file not found\n")
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
============================================================================================
b86603bc9e3fd10ac3d7c5304e12d6d97333f785 Fixes:
On Apple Silicon macOS using Homebrew, the linker cannot find the library files,
they are places under the /opt/homebrew/lib/ directory.

```stderr
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "/var/folders/0b/bj94qkyx3151ngjt0n16lsq00000gn/T/rustcv9NYrR/symbols.o" "<183 object files omitted>" "/Users/viktorsandstrom/Documents/rust/tau-radio/target/debug/deps/{libto
ml-edeb5f6b91f89dad,libtoml_writer-be563ea20964558a,libtoml_parser-6ee1e23e6ad6c297,libwinnow-bc4954aee1fac96d,libserde_spanned-0d669bf8c6aca990,libtoml_datetime-0b8e486599d8a140,libringbuf-e
dd51786f0d577a7,libcrossbeam_utils-dae249fdcb8642cb,libopusenc-c5945ec26d8b48c5,libnum_enum-31b6c1a32166c759,libopusenc_sys-90ee38c1c97e1fb6,libcpal-f7d84b00d16e1d5c,libmach2-d30b2e7575f62ec0
,libdasp_sample-408ba99f7d36efd4,libcoreaudio-e41cf25e9cf95066,libobjc2_audio_toolbox-c87f0fd45e46e4ce,libobjc2_core_audio-127ac08140a432ae,libobjc2_core_foundation-d844312f60ffe197,libbitfla
gs-39a7ca4caa9527c6,libobjc2_core_audio_types-4c2b7fa317fce952,libobjc2-f3e255cdeb23489e,libobjc2_encode-881d775584ddb46b,libchrono-e165f9eeea425dbc,libiana_time_zone-038763bf2a4efbef,libcore
_foundation_sys-5561f19f53e141c4,libnum_traits-2ca2b571eb077c71,libshout-e5bb07c5c89b7f0c,libshout_sys-a7aa157b664f9110,libinline_colorization-5da3bd1052d72377,libclap-86d46e12cf80584f,libcla
p_builder-0d57c828dc33e255,libstrsim-aa571f77a7648d17,libanstream-0520df850551cc3b,libanstyle_query-dd564e3c57fad863,libis_terminal_polyfill-5d75fb396f949567,libcolorchoice-437d4f73ec324d81,l
ibanstyle_parse-9ff73b9ad9f94d11,libutf8parse-08ac224b95907b39,libclap_lex-d412d889f3a37318,libanstyle-e40cb05033670ea0,libis_ip-ef1d42c39cfe6c61,libregex-dd9dac4ec545ef22,libregex_automata-2
f4ad74c689db45f,libaho_corasick-10e085936f689a8a,libmemchr-7ffb20de63eb96b4,libregex_syntax-9cc2e2c88f88eb51,libdialoguer-cf3ddc6042c1f317,libshell_words-f048c85dd8d10d79,libtempfile-05a094bf
1de1fc41,libgetrandom-c04ef62f4839c058,libcfg_if-b7a756bc843dd0d0,libfastrand-9e481926b25db16a,librustix-128a7438e2bdabff,libbitflags-8fc1bc76c9d42065,liberrno-b1ac3a0a01fc3aec,libzeroize-0cc
f2a5796ce0222,libthiserror-3aadcf5a0e4780e4,libconsole-111a4f2558943a55,liblibc-38ea366e9259f30e,libunicode_width-dbe649264615a3b5,libonce_cell-e22bb08fb883a9e7,libserde-d7c84867a226ecbc}.rli
b" "<sysroot>/lib/rustlib/aarch64-apple-darwin/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_st
d_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-lopusenc" "-framework" "A
udioToolbox" "-framework" "CoreAudio" "-framework" "CoreFoundation" "-lobjc" "-framework" "Foundation" "-framework" "CoreFoundation" "-lshout" "-liconv" "-lSystem" "-lc" "-lm" "-arch" "arm64"
 "-mmacosx-version-min=11.0.0" "-o" "/Users/viktorsandstrom/Documents/rust/tau-radio/target/debug/deps/radio_stream-4a47b80b289b3d6c" "-Wl,-dead_strip" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: ld: library 'opusenc' not found
          clang: error: linker command failed with exit code 1 (use -v to see invocation)


warning: `radio_stream` (bin "radio_stream") generated 6 warnings
error: could not compile `radio_stream` (bin "radio_stream") due to 1 previous error; 6 warnings emitted
```
============================================================================================
a34856a6f6e9887d606b43d67aeb09e76995d46f Fixes:
Homebrew on macOS using Apple Silicon does not install under /usr/include/opus/, but under the /opt/homebrew/include

```stderr
   Compiling opusenc-sys v0.2.2
error: failed to run custom build command for `opusenc-sys v0.2.2`

Caused by:
  process didn't exit successfully: `/Users/viktorsandstrom/Documents/rust/tau-radio/target/debug/build/opusenc-sys-cbed859fac7156b2/build-script-build` (exit status: 101)
  --- stdout
  cargo:rustc-link-lib=opusenc
  cargo:rerun-if-changed=wrapper.h
  cargo:rerun-if-env-changed=TARGET
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_aarch64-apple-darwin
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS
  cargo:rerun-if-changed=wrapper.h

  --- stderr
  wrapper.h:1:10: fatal error: 'opus/opus_defines.h' file not found

  thread 'main' (9635381) panicked at /Users/viktorsandstrom/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opusenc-sys-0.2.2/build.rs:13:10:
  Unable to generate bindings: ClangDiagnostic("wrapper.h:1:10: fatal error: 'opus/opus_defines.h' file not found\n")
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
